### PR TITLE
fix (JavaScript): Use ESM and remove unnecessary syntax.

### DIFF
--- a/Nodejs/Node-Fetch/fetch-get-request-with-auth.js
+++ b/Nodejs/Node-Fetch/fetch-get-request-with-auth.js
@@ -1,18 +1,14 @@
-const fetch = require('node-fetch'); // Don't need for HTML Websites.
+import fetch from "node-fetch";
 
-const url = "https://api.snowflakedev.org/api/stats"
+const url = "https://api.snowflakedev.org/api/stats";
+
 fetch(url, {
     method: "GET",
     headers: {
-        "Authorization": "API_KEY" // Can be obtained from https://api.snowflakedev.org/dashboard (This example will use snowflakedev's API.)
-    }
-}).then(function (response) {
-    if (response.ok) {
-            // If the response went through and returns 200 OK
-        response.json().then(function (data) {
-            console.log(data); // Console logs data from api
-        });
-    } else {
-        console.log("Response failed...");
-    }
+        "Authorization": "API_KEY", // Can be obtained from https://api.snowflakedev.org/dashboard (This example will use snowflakedev's API.)
+    },
+}).then((response) => {
+    if (response.ok) // Checks if the response's status was 200 (OK).
+        response.json().then(console.log); // Logs data to console.
+    else console.log("Response failed...");
 });

--- a/Nodejs/Node-Fetch/fetch-get-request.js
+++ b/Nodejs/Node-Fetch/fetch-get-request.js
@@ -13,3 +13,13 @@ fetch(url, {
         console.log("Response failed...");
     }
 });
+
+import fetch from "node-fetch";
+
+const url = "https://api.example.com/v1/examples";
+
+fetch(url).then((response) => {
+    if (response.ok) // Checks if the response's status was 200 (OK).
+        response.json().then(console.log); // Logs data to console.
+    else console.log("Response failed...");
+});


### PR DESCRIPTION
The current version of node-fetch uses ESM, and cannot be used with commonjs.

This PR also removes unnecessary syntax like brackets, classic functions, etc.